### PR TITLE
Update to newer .Net Runtime & Fix on Mono w/out Wine

### DIFF
--- a/MSCPatcher/MSCPatcher/DebugStuff.cs
+++ b/MSCPatcher/MSCPatcher/DebugStuff.cs
@@ -14,7 +14,7 @@ namespace MSCPatcher
         {
             if (Form1.mscPath != "(unknown)")
             {
-                monoPath = Path.Combine(Form1.mscPath, @"mysummercar_Data\Mono\mono.dll");
+                monoPath = Path.Combine(Form1.mscPath, @"mysummercar_Data/Mono/mono.dll");
                 switch(Form1.MD5HashFile(monoPath))
                 {
                     case MD5FileHashes.mono32normal:

--- a/MSCPatcher/MSCPatcher/Form1.Designer.cs
+++ b/MSCPatcher/MSCPatcher/Form1.Designer.cs
@@ -536,6 +536,7 @@
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "Form1";
             this.Text = "ModLoader for My Summer Car";
+            this.Load += new System.EventHandler(this.Form1_Load);
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
             this.tabControl1.ResumeLayout(false);

--- a/MSCPatcher/MSCPatcher/Form1.cs
+++ b/MSCPatcher/MSCPatcher/Form1.cs
@@ -16,11 +16,11 @@ namespace MSCPatcher
         public static Form1 form1;
         public static string mscPath = "(unknown)";
 
-        private string AssemblyPath = @"mysummercar_Data\Managed\Assembly-CSharp.dll";
+        private string AssemblyPath = @"mysummercar_Data/Managed/Assembly-CSharp.dll";
         private string AssemblyFullPath = null;
         private string InitMethod = "Init_MD";
-        private string mdPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), @"MySummerCar\Mods");
-        private string adPath = Path.GetFullPath(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), @"..\LocalLow\Amistech\My Summer Car\Mods"));
+        private string mdPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), @"MySummerCar/Mods");
+        private string adPath = Path.GetFullPath(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), @"../LocalLow/Amistech/My Summer Car/Mods"));
         private string gfPath = "?";
         private string modPath = "";
 
@@ -239,12 +239,12 @@ namespace MSCPatcher
             {
                 Log.Write("Cleaning old files!", true, true);
                 //Remove old 0.1 unused files and patch game
-                Patcher.DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data\Managed\Assembly-CSharp.original.dll"));
-                Patcher.DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data\Managed\Mono.Cecil.dll"));
-                Patcher.DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data\Managed\Mono.Cecil.Rocks.dll"));
-                Patcher.DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data\Managed\MSCLoader.dll"));
-                Patcher.DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data\Managed\MSCPatcher.exe"));
-                Patcher.DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data\Managed\System.Xml.dll"));
+                Patcher.DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data/Managed/Assembly-CSharp.original.dll"));
+                Patcher.DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data/Managed/Mono.Cecil.dll"));
+                Patcher.DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data/Managed/Mono.Cecil.Rocks.dll"));
+                Patcher.DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data/Managed/MSCLoader.dll"));
+                Patcher.DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data/Managed/MSCPatcher.exe"));
+                Patcher.DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data/Managed/System.Xml.dll"));
 
                 StartPatching();
             }
@@ -258,7 +258,7 @@ namespace MSCPatcher
             }
             else if (oldPatchFound)
             {
-                if (File.Exists(Path.Combine(mscPath, @"mysummercar_Data\Managed\Assembly-CSharp.original.dll")))
+                if (File.Exists(Path.Combine(mscPath, @"mysummercar_Data/Managed/Assembly-CSharp.original.dll")))
                 {
                     if (File.Exists(AssemblyFullPath))
                     {
@@ -266,29 +266,29 @@ namespace MSCPatcher
 
                         Patcher.DeleteIfExists(AssemblyFullPath);
 
-                        File.Move(Path.Combine(mscPath, @"mysummercar_Data\Managed\Assembly-CSharp.original.dll"), AssemblyFullPath);
+                        File.Move(Path.Combine(mscPath, @"mysummercar_Data/Managed/Assembly-CSharp.original.dll"), AssemblyFullPath);
                         Log.Write("Recovering.....Assembly-CSharp.original.dll");
                     }
                     else
                     {
                         Log.Write("Recovering backup file!", true, true);
 
-                        File.Move(Path.Combine(mscPath, @"mysummercar_Data\Managed\Assembly-CSharp.original.dll"), AssemblyFullPath);
+                        File.Move(Path.Combine(mscPath, @"mysummercar_Data/Managed/Assembly-CSharp.original.dll"), AssemblyFullPath);
                         Log.Write("Recovering.....Assembly-CSharp.original.dll");
                     }
                     //Removing old files
                     Log.Write("Cleaning old files!", true, true);
-                    Patcher.DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data\Managed\Mono.Cecil.dll"));
-                    Patcher.DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data\Managed\Mono.Cecil.Rocks.dll"));
-                    Patcher.DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data\Managed\MSCLoader.dll"));
-                    Patcher.DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data\Managed\MSCPatcher.exe"));
-                    Patcher.DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data\Managed\System.Xml.dll"));
+                    Patcher.DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data/Managed/Mono.Cecil.dll"));
+                    Patcher.DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data/Managed/Mono.Cecil.Rocks.dll"));
+                    Patcher.DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data/Managed/MSCLoader.dll"));
+                    Patcher.DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data/Managed/MSCPatcher.exe"));
+                    Patcher.DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data/Managed/System.Xml.dll"));
 
                     StartPatching();
                 }
                 else
                 {
-                    MessageBox.Show(string.Format("0.1 backup file not found in:{1}{0}{1}Can't continue with upgrade{1}{1}Please check integrity files in steam, to recover original file.", Path.Combine(mscPath, @"mysummercar_Data\Managed\Assembly-CSharp.original.dll"), Environment.NewLine), "Error!", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(string.Format("0.1 backup file not found in:{1}{0}{1}Can't continue with upgrade{1}{1}Please check integrity files in steam, to recover original file.", Path.Combine(mscPath, @"mysummercar_Data/Managed/Assembly-CSharp.original.dll"), Environment.NewLine), "Error!", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     statusBarLabel.Text = "Error!";
                 }
             }
@@ -321,7 +321,7 @@ namespace MSCPatcher
                 File.Copy(AssemblyFullPath, string.Format("{0}.backup", AssemblyFullPath));
                 Log.Write("Creating.....Assembly-CSharp.dll.backup");
                 Log.Write(string.Format("Patching.....{0}", Path.GetFileName(AssemblyFullPath)));
-                PatchThis(Path.Combine(mscPath, @"mysummercar_Data\Managed\"), "Assembly-CSharp.dll", "PlayMakerArrayListProxy", "Awake", "MSCLoader.dll", "MSCLoader.ModLoader", InitMethod);
+                PatchThis(Path.Combine(mscPath, @"mysummercar_Data/Managed/"), "Assembly-CSharp.dll", "PlayMakerArrayListProxy", "Awake", "MSCLoader.dll", "MSCLoader.ModLoader", InitMethod);
                 Log.Write("Finished patching!");
 
                 Patcher.CopyCoreAssets(modPath);
@@ -451,11 +451,11 @@ namespace MSCPatcher
             {
                 bool isInjected = false;
                 if (MDradio.Checked)
-                    isInjected = IsPatched(Path.Combine(mscPath, @"mysummercar_Data\Managed\Assembly-CSharp.dll"), "PlayMakerArrayListProxy", "Awake", "MSCLoader.dll", "MSCLoader.ModLoader", "Init_MD");
+                    isInjected = IsPatched(Path.Combine(mscPath, @"mysummercar_Data/Managed/Assembly-CSharp.dll"), "PlayMakerArrayListProxy", "Awake", "MSCLoader.dll", "MSCLoader.ModLoader", "Init_MD");
                 else if (GFradio.Checked)
-                    isInjected = IsPatched(Path.Combine(mscPath, @"mysummercar_Data\Managed\Assembly-CSharp.dll"), "PlayMakerArrayListProxy", "Awake", "MSCLoader.dll", "MSCLoader.ModLoader", "Init_GF");
+                    isInjected = IsPatched(Path.Combine(mscPath, @"mysummercar_Data/Managed/Assembly-CSharp.dll"), "PlayMakerArrayListProxy", "Awake", "MSCLoader.dll", "MSCLoader.ModLoader", "Init_GF");
                 else if (ADradio.Checked)
-                    isInjected = IsPatched(Path.Combine(mscPath, @"mysummercar_Data\Managed\Assembly-CSharp.dll"), "PlayMakerArrayListProxy", "Awake", "MSCLoader.dll", "MSCLoader.ModLoader", "Init_AD");
+                    isInjected = IsPatched(Path.Combine(mscPath, @"mysummercar_Data/Managed/Assembly-CSharp.dll"), "PlayMakerArrayListProxy", "Awake", "MSCLoader.dll", "MSCLoader.ModLoader", "Init_AD");
 
                 if (isInjected)
                     newpatchfound = true;
@@ -471,7 +471,7 @@ namespace MSCPatcher
             {
                 try
                 {
-                    bool isInjected = IsPatched(Path.Combine(mscPath, @"mysummercar_Data\Managed\Assembly-CSharp.dll"), "StartGame", ".ctor", "MSCLoader.dll", "MSCLoader.ModLoader", "Init");
+                    bool isInjected = IsPatched(Path.Combine(mscPath, @"mysummercar_Data/Managed/Assembly-CSharp.dll"), "StartGame", ".ctor", "MSCLoader.dll", "MSCLoader.ModLoader", "Init");
                     if (isInjected)
                         oldpatchfound = true;
                     else
@@ -485,7 +485,7 @@ namespace MSCPatcher
             }
             if (!newpatchfound && !oldpatchfound)
             {
-                if (File.Exists(Path.Combine(mscPath, @"mysummercar_Data\Managed\Assembly-CSharp.original.dll")))
+                if (File.Exists(Path.Combine(mscPath, @"mysummercar_Data/Managed/Assembly-CSharp.original.dll")))
                 {
                     statusLabelText.Text = "Not patched, but MSCLoader 0.1 found (probably there was game update)";
                     Log.Write("Patch not found, but MSCLoader 0.1 files found (probably there was game update)");
@@ -493,7 +493,7 @@ namespace MSCPatcher
                     button1.Enabled = true;
                     oldFilesFound = true;
                 }
-                else if (File.Exists(Path.Combine(mscPath, @"mysummercar_Data\Managed\MSCLoader.dll")) && File.Exists(Path.Combine(mscPath, @"mysummercar_Data\Managed\Assembly-CSharp.dll.backup")))
+                else if (File.Exists(Path.Combine(mscPath, @"mysummercar_Data/Managed/MSCLoader.dll")) && File.Exists(Path.Combine(mscPath, @"mysummercar_Data/Managed/Assembly-CSharp.dll.backup")))
                 {
                     statusLabelText.Text = "Not patched, but MSCLoader found (probably there was game update)";
                     Log.Write("Patch not found, but MSCLoader files found (looks like there was game update)");
@@ -512,7 +512,7 @@ namespace MSCPatcher
             }
             else if (newpatchfound)
             {
-                if (MD5HashFile(Path.Combine(mscPath, @"mysummercar_Data\Managed\MSCLoader.dll")) == MD5HashFile(Path.GetFullPath(Path.Combine("MSCLoader.dll", ""))))
+                if (MD5HashFile(Path.Combine(mscPath, @"mysummercar_Data/Managed/MSCLoader.dll")) == MD5HashFile(Path.GetFullPath(Path.Combine("MSCLoader.dll", ""))))
                 {
                     statusLabelText.Text = "Installed, MSCLoader.dll is up to date.";
                     Log.Write("Newest patch found, no need to patch again");
@@ -681,6 +681,11 @@ namespace MSCPatcher
             assembly.Dispose();
             loader.Dispose();
             return false;
+        }
+
+        private void Form1_Load(object sender, EventArgs e)
+        {
+
         }
     }
 }

--- a/MSCPatcher/MSCPatcher/MSCPatcher.csproj
+++ b/MSCPatcher/MSCPatcher/MSCPatcher.csproj
@@ -8,7 +8,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>MSCPatcher</RootNamespace>
     <AssemblyName>MSCPatcher</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <PublishUrl>publish\</PublishUrl>
@@ -25,6 +25,7 @@
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -35,6 +36,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -44,30 +46,29 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>mscpatchericon.ico</ApplicationIcon>
   </PropertyGroup>
   <PropertyGroup />
   <ItemGroup>
-    <Reference Include="Ionic.Zip, Version=1.9.1.5, Culture=neutral, PublicKeyToken=edbe51ad942a3f5c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\Steam\steamapps\common\My Summer Car\mysummercar_Data\Managed\Ionic.Zip.dll</HintPath>
+    <Reference Include="Mono.Cecil, Version=0.11.2.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.2\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Cecil, Version=0.10.3.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.10.3\lib\net40\Mono.Cecil.dll</HintPath>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.11.2.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.2\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Cecil.Mdb, Version=0.10.3.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.10.3\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.11.2.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.2\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Cecil.Pdb, Version=0.10.3.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.10.3\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Rocks, Version=0.10.3.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.10.3\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.11.2.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.2\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
@@ -103,7 +104,9 @@
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
+      <DesignTime>True</DesignTime>
     </Compile>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>

--- a/MSCPatcher/MSCPatcher/MainData.cs
+++ b/MSCPatcher/MSCPatcher/MainData.cs
@@ -16,7 +16,7 @@ namespace MSCPatcher
         {
             if (Form1.mscPath != "(unknown)")
             {
-                mainDataPath = Path.Combine(Form1.mscPath, @"mysummercar_Data\mainData");
+                mainDataPath = Path.Combine(Form1.mscPath, @"mysummercar_Data/mainData");
                 offset = FindBytes(mainDataPath, data);
                 try
                 {

--- a/MSCPatcher/MSCPatcher/Patcher.cs
+++ b/MSCPatcher/MSCPatcher/Patcher.cs
@@ -1,4 +1,3 @@
-﻿//using Ionic.Zip;
 using System.IO.Compression;
 using System;
 using System.IO;
@@ -25,19 +24,6 @@ namespace MSCPatcher
             DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data/Managed/Ionic.Zip.dll"));
             try
             {
-                //if (!File.Exists(Path.Combine("References.zip", "")))
-                //    throw new Exception("References.zip not found");
-                //string zip = Path.Combine("References.zip", "");
-                //if (!ZipFile.IsZipFile(zip))
-                //{
-                //    throw new Exception("Failed to read zip file");
-                //}
-                //ZipFile zip1 = ZipFile.Read(zip);
-                //foreach (ZipEntry zz in zip1)
-                //{
-                //    Log.Write("Removing file....." + zz.FileName);
-                //    DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data/Managed/" + zz.FileName));
-                //}
                 if (!File.Exists("References.zip"))
                 {
                     throw new Exception("References.zip not found");

--- a/MSCPatcher/MSCPatcher/Patcher.cs
+++ b/MSCPatcher/MSCPatcher/Patcher.cs
@@ -1,4 +1,5 @@
-﻿using Ionic.Zip;
+﻿//using Ionic.Zip;
+using System.IO.Compression;
 using System;
 using System.IO;
 using System.Windows.Forms;
@@ -17,25 +18,36 @@ namespace MSCPatcher
         }
         public static void DeleteReferences(string mscPath)
         {
-            DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data\Managed\MSCLoader.dll"));
-            DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data\Managed\MSCLoader.dll.mdb"));
-            DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data\Managed\MSCLoader.pdb"));
-            DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data\Managed\uAudio.dll"));
-            DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data\Managed\Ionic.Zip.dll"));
+            DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data/Managed/MSCLoader.dll"));
+            DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data/Managed/MSCLoader.dll.mdb"));
+            DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data/Managed/MSCLoader.pdb"));
+            DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data/Managed/uAudio.dll"));
+            DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data/Managed/Ionic.Zip.dll"));
             try
             {
-                if (!File.Exists(Path.Combine("References.zip", "")))
+                //if (!File.Exists(Path.Combine("References.zip", "")))
+                //    throw new Exception("References.zip not found");
+                //string zip = Path.Combine("References.zip", "");
+                //if (!ZipFile.IsZipFile(zip))
+                //{
+                //    throw new Exception("Failed to read zip file");
+                //}
+                //ZipFile zip1 = ZipFile.Read(zip);
+                //foreach (ZipEntry zz in zip1)
+                //{
+                //    Log.Write("Removing file....." + zz.FileName);
+                //    DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data/Managed/" + zz.FileName));
+                //}
+                if (!File.Exists("References.zip"))
+                {
                     throw new Exception("References.zip not found");
-                string zip = Path.Combine("References.zip", "");
-                if (!ZipFile.IsZipFile(zip))
-                {
-                    throw new Exception("Failed to read zip file");
                 }
-                ZipFile zip1 = ZipFile.Read(zip);
-                foreach (ZipEntry zz in zip1)
+                using (var zip = ZipFile.OpenRead("References.zip"))
                 {
-                    Log.Write("Removing file....." + zz.FileName);
-                    DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data\Managed\" + zz.FileName));
+                    foreach(ZipArchiveEntry e in zip.Entries)
+                    {
+                        DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data/Managed/" + e.Name));
+                    }
                 }
             }
             catch (Exception ex)
@@ -47,53 +59,46 @@ namespace MSCPatcher
         }
         public static void CopyReferences(string mscPath)
         {
-            DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data\Managed\MSCLoader.dll"));
-            DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data\Managed\MSCLoader.dll.mdb"));
-            DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data\Managed\MSCLoader.pdb"));
-            DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data\Managed\uAudio.dll"));
-            DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data\Managed\Ionic.Zip.dll"));
+            DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data/Managed/MSCLoader.dll"));
+            DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data/Managed/MSCLoader.dll.mdb"));
+            DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data/Managed/MSCLoader.pdb"));
+            DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data/Managed/uAudio.dll"));
+            DeleteIfExists(Path.Combine(mscPath, @"mysummercar_Data/Managed/Ionic.Zip.dll"));
 
             if (File.Exists(Path.GetFullPath(Path.Combine("MSCLoader.dll", ""))))
             {
-                File.Copy(Path.GetFullPath(Path.Combine("MSCLoader.dll", "")), Path.Combine(mscPath, @"mysummercar_Data\Managed\MSCLoader.dll"));
+                File.Copy(Path.GetFullPath(Path.Combine("MSCLoader.dll", "")), Path.Combine(mscPath, @"mysummercar_Data/Managed/MSCLoader.dll"));
                 Log.Write("Copying new file.....MSCLoader.dll");
             }
 
             if (File.Exists(Path.GetFullPath(Path.Combine("MSCLoader.dll.mdb", ""))))
             {
-                File.Copy(Path.GetFullPath(Path.Combine("MSCLoader.dll.mdb", "")), Path.Combine(mscPath, @"mysummercar_Data\Managed\MSCLoader.dll.mdb"));
+                File.Copy(Path.GetFullPath(Path.Combine("MSCLoader.dll.mdb", "")), Path.Combine(mscPath, @"mysummercar_Data/Managed/MSCLoader.dll.mdb"));
                 Log.Write("Copying new file.....MSCLoader.dll.mdb");
             }
 
             if (File.Exists(Path.GetFullPath(Path.Combine("MSCLoader.pdb", ""))))
             {
-                File.Copy(Path.GetFullPath(Path.Combine("MSCLoader.pdb", "")), Path.Combine(mscPath, @"mysummercar_Data\Managed\MSCLoader.pdb"));
+                File.Copy(Path.GetFullPath(Path.Combine("MSCLoader.pdb", "")), Path.Combine(mscPath, @"mysummercar_Data/Managed/MSCLoader.pdb"));
                 Log.Write("Copying new file.....MSCLoader.pdb");
             }
             if (File.Exists(Path.GetFullPath(Path.Combine("Ionic.Zip.dll", ""))))
             {
-                File.Copy(Path.GetFullPath(Path.Combine("Ionic.Zip.dll", "")), Path.Combine(mscPath, @"mysummercar_Data\Managed\Ionic.Zip.dll"));
+                File.Copy(Path.GetFullPath(Path.Combine("Ionic.Zip.dll", "")), Path.Combine(mscPath, @"mysummercar_Data/Managed/Ionic.Zip.dll"));
                 Log.Write("Copying new file.....Ionic.Zip.dll");
             }
             try
             {
-                if (!File.Exists(Path.Combine("References.zip", "")))
+                if (!File.Exists("References.zip"))
                     throw new Exception("References.zip not found");
                 string zip = Path.Combine("References.zip","");
-                if (!ZipFile.IsZipFile(zip))
-                {
-                    throw new Exception("Failed read zip file");
-                }
-                ZipFile zip1 = ZipFile.Read(zip);
-                foreach (ZipEntry zz in zip1)
-                {
-                    Log.Write("Copying new file....." + zz.FileName);
-                    zz.Extract(Path.Combine(mscPath, @"mysummercar_Data\Managed\"), ExtractExistingFileAction.OverwriteSilently);
-                }
+
+                ZipFile.ExtractToDirectory("References.zip", Path.Combine(mscPath, @"mysummercar_Data/Managed/"));
+
             }
             catch (Exception ex)
             {
-                MessageBox.Show(string.Format("Error while unpacking references: {0}", ex.Message), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(string.Format("Error while unpacking references: {0}", ex), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 Log.Write(string.Format("Error while unpacking references: {0}", ex.Message));
             }
         }
@@ -102,30 +107,30 @@ namespace MSCPatcher
         {
             Log.Write("Copying Core Assets.....MSCLoader_Core");
 
-            if (!Directory.Exists(Path.Combine(modPath, @"Assets\MSCLoader_Core")))
-                Directory.CreateDirectory(Path.Combine(modPath, @"Assets\MSCLoader_Core"));
+            if (!Directory.Exists(Path.Combine(modPath, @"Assets/MSCLoader_Core")))
+                Directory.CreateDirectory(Path.Combine(modPath, @"Assets/MSCLoader_Core"));
             else
-                File.Delete(Path.Combine(modPath, @"Assets\MSCLoader_Core\core.unity3d"));
+                File.Delete(Path.Combine(modPath, @"Assets/MSCLoader_Core/core.unity3d"));
 
-            File.Copy(Path.GetFullPath(Path.Combine(@"Assets\MSCLoader_Core", "core.unity3d")), Path.Combine(modPath, @"Assets\MSCLoader_Core\core.unity3d"));
+            File.Copy(Path.GetFullPath(Path.Combine(@"Assets/MSCLoader_Core", "core.unity3d")), Path.Combine(modPath, @"Assets/MSCLoader_Core/core.unity3d"));
 
             Log.Write("Copying Core Assets.....MSCLoader_Settings");
 
-            if (!Directory.Exists(Path.Combine(modPath, @"Assets\MSCLoader_Settings")))
-                Directory.CreateDirectory(Path.Combine(modPath, @"Assets\MSCLoader_Settings"));
+            if (!Directory.Exists(Path.Combine(modPath, @"Assets/MSCLoader_Settings")))
+                Directory.CreateDirectory(Path.Combine(modPath, @"Assets/MSCLoader_Settings"));
             else
-                File.Delete(Path.Combine(modPath, @"Assets\MSCLoader_Settings\settingsui.unity3d"));
+                File.Delete(Path.Combine(modPath, @"Assets/MSCLoader_Settings/settingsui.unity3d"));
 
-            File.Copy(Path.GetFullPath(Path.Combine(@"Assets\MSCLoader_Settings", "settingsui.unity3d")), Path.Combine(modPath, @"Assets\MSCLoader_Settings\settingsui.unity3d"));
+            File.Copy(Path.GetFullPath(Path.Combine(@"Assets/MSCLoader_Settings", "settingsui.unity3d")), Path.Combine(modPath, @"Assets/MSCLoader_Settings/settingsui.unity3d"));
 
             Log.Write("Copying Core Assets.....MSCLoader_Console");
 
-            if (!Directory.Exists(Path.Combine(modPath, @"Assets\MSCLoader_Console")))
-                Directory.CreateDirectory(Path.Combine(modPath, @"Assets\MSCLoader_Console"));
+            if (!Directory.Exists(Path.Combine(modPath, @"Assets/MSCLoader_Console")))
+                Directory.CreateDirectory(Path.Combine(modPath, @"Assets/MSCLoader_Console"));
             else
-                File.Delete(Path.Combine(modPath, @"Assets\MSCLoader_Console\console.unity3d"));
+                File.Delete(Path.Combine(modPath, @"Assets/MSCLoader_Console/console.unity3d"));
 
-            File.Copy(Path.GetFullPath(Path.Combine(@"Assets\MSCLoader_Console", "console.unity3d")), Path.Combine(modPath, @"Assets\MSCLoader_Console\console.unity3d"));
+            File.Copy(Path.GetFullPath(Path.Combine(@"Assets/MSCLoader_Console", "console.unity3d")), Path.Combine(modPath, @"Assets/MSCLoader_Console/console.unity3d"));
 
             Log.Write("Copying Core Assets Completed!", false, true);
         }

--- a/MSCPatcher/MSCPatcher/Properties/Resources.Designer.cs
+++ b/MSCPatcher/MSCPatcher/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace MSCPatcher.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/MSCPatcher/MSCPatcher/Properties/Settings.Designer.cs
+++ b/MSCPatcher/MSCPatcher/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace MSCPatcher.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.3.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.5.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/MSCPatcher/MSCPatcher/app.config
+++ b/MSCPatcher/MSCPatcher/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/MSCPatcher/MSCPatcher/packages.config
+++ b/MSCPatcher/MSCPatcher/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Mono.Cecil" version="0.10.3" targetFramework="net40" />
+  <package id="Mono.Cecil" version="0.11.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
It stopped working on Wine for me out of nowhere, so I ran it directly in Mono, and experienced numerous issues, mostly to do with the slashes being the wrong direction, which doesn't matter on Windows, but *does* matter on Linux and MacOS. I corrected that, then ran into an issue with Ionic.zip, which prompted me to remove it, upgrade the .Net version to 4.5, and use the built in .zip file handling, which is cleaner imho.
