### PR TITLE
 Changing to exe directory at the start. 

### DIFF
--- a/MSCPatcher/MSCPatcher/Form1.cs
+++ b/MSCPatcher/MSCPatcher/Form1.cs
@@ -37,6 +37,12 @@ namespace MSCPatcher
             form1 = this;
             InitializeComponent();
             Log.logBox = logBox;
+
+            // Change to the directory containing the exe.
+            // This allows running the exe from the commandline in another
+            // folder while still working with the existing path logic.
+            Directory.SetCurrentDirectory(AppDomain.CurrentDomain.BaseDirectory);
+
             if (File.Exists("Assembly-CSharp.dll") || File.Exists("UnityEngine.dll") || File.Exists("mysummercar.exe") || File.Exists("mainData") || File.Exists("mono.dll") || File.Exists("CSteamworks.dll") || Directory.Exists("References")) //check if idiot unpacked this to game folder.
             {
                 if (MessageBox.Show("Did you read the instructions? (Readme.txt)", "Question for you!", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)


### PR DESCRIPTION
The "idiot" checks in `Form1` make installing on Linux under Steam Play/Proton harder than it needs to be.

First it checks for files from the MSC game folder and later it tries to load a file that should be in the folder where it was extracted to.

To be able to use this it's necessary to change the directory Steam runs the exe in manually as it defaults to the game folder. The unofficial Linux guide advises a rather roundabout way to work around this by using a very long and complicated command line to manually run the exe (in a different folder). It is significantly simpler to just do this:
```bash
eval "$(echo "%command%" | sed @My Summer Car/mysummercar.exe@MSCLoader/MSCPatcher.exe@)"
```
It just tricks Steam into launching the patcher in a folder adjacent to the game folder. On Linux this folder is not located in a problematic folder like Program Files so there is no problem in doing this, it could even be in a subfolder of the game folder.

However, this doesn't work because Steam still runs the exe inside the game folder, so it will fail to pass either of the "idiot" checks.

I eventually got it working by going the roundabout way, but this peaked my interest enough to take a crack at improving it.

The fix is simple, we just switch the current directory to wherever the exe is using:
```cs
Directory.SetCurrentDirectory(AppDomain.CurrentDomain.BaseDirectory);
```

This will not allow the user to bypass the game folder check, but it will allow the program to find the files it looks for.

Additionally in order to make it simpler to set this project up in Visual Studio I changed the dependencies to use Nuget, this way anyone who clones the project doesn't need to manually copy DLLs to some directory, Visual Studio will simply download it when you first build it.

I'd also strongly encourage updating the target framework of this project as .NET Framework 4.0 is extremely out of date and not even supported by VS 2022 (doesn't show up in the installer, there may be workarounds but it's far from being a simple task), I ended up having to install VS 2019 to find the option for ".NET 4 Targeting Pack" in the installer.

If 4.8.1 or newer is considered too risky to break existing user installs, consider targeting something that the VS2022 installer will still list, such as 4.6 (still needlessly old IMO). [Here's a table of all the versions supported by various WIndows versions.](https://learn.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#detect-net-framework-45-and-later-versions)

In any case, I've tested this myself and it works fine, the patcher is able to install from a different directory than where its exe and resources are located.

Thanks for the tool regardless.