### PR TITLE
fix: improve Linux/Proton compatibility (SystemInfo + output log paths)

### DIFF
--- a/MSCLoader/MSCLoader.Preloader/MainEntry.cs
+++ b/MSCLoader/MSCLoader.Preloader/MainEntry.cs
@@ -152,6 +152,17 @@ namespace MSCLoader.Preloader
         }
         private static void OutputLogChecker()
         {
+            // Binary patching mainData is Windows-specific (offsets differ on Linux builds).
+            // On native Linux, Unity logs to Player.log by default and doesn't need patching.
+            // Only skip for native Linux — Proton uses Windows binaries so patching is fine.
+            if (Environment.GetEnvironmentVariable("STEAM_COMPAT_DATA_PATH") == null
+                && Environment.GetEnvironmentVariable("WINEPREFIX") == null
+                && Environment.OSVersion.Platform == PlatformID.Unix)
+            {
+                MDebug.Log("Skipping OutputLogChecker (native Linux detected, Player.log is used by default)");
+                return;
+            }
+
             try
             {
                 bool enLog = false;

--- a/MSCLoader/MSCLoader/ModLoader.Internal.cs
+++ b/MSCLoader/MSCLoader/ModLoader.Internal.cs
@@ -105,8 +105,47 @@ public partial class ModLoader
     void OnApplicationQuit()
     {
         //Save current log as "previous"
-        if (File.Exists("output_log_previous.txt")) File.Delete("output_log_previous.txt");
-        File.Copy("output_log.txt", "output_log_previous.txt");
+        try
+        {
+            string logPath = GetOutputLogPath();
+            if (logPath != null)
+            {
+                string prevPath = GetOutputLogPreviousPath();
+                if (File.Exists(prevPath)) File.Delete(prevPath);
+                File.Copy(logPath, prevPath);
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Failed to copy output log: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Resolves the path to the Unity output log file.
+    /// Windows/Proton: output_log.txt in game directory.
+    /// Linux native: Player.log in Application.persistentDataPath.
+    /// </summary>
+    internal static string GetOutputLogPath()
+    {
+        if (File.Exists("output_log.txt"))
+            return Path.GetFullPath("output_log.txt");
+        string playerLog = Path.Combine(Application.persistentDataPath, "Player.log");
+        if (File.Exists(playerLog))
+            return playerLog;
+        if (File.Exists("Player.log"))
+            return Path.GetFullPath("Player.log");
+        return null;
+    }
+
+    internal static string GetOutputLogPreviousPath()
+    {
+        string logPath = GetOutputLogPath();
+        if (logPath == null) return null;
+        string dir = Path.GetDirectoryName(logPath);
+        string name = Path.GetFileNameWithoutExtension(logPath);
+        string ext = Path.GetExtension(logPath);
+        return Path.Combine(dir, $"{name}_previous{ext}");
     }
 
     internal static string SidChecksumCalculator(string rawData)
@@ -135,16 +174,32 @@ public partial class ModLoader
                     windowsfixed = $"Windows 11 (10.0.{build})";
                     if (Sinfo.Contains("64bit"))
                         windowsfixed += " 64bit";
-                    return windowsfixed;
                 }
                 else if (build > 9841)
                 {
                     windowsfixed = $"Windows 10 (10.0.{build})";
                     if (Sinfo.Contains("64bit"))
                         windowsfixed += " 64bit";
-                    return windowsfixed;
                 }
-                else return Sinfo;
+                else
+                {
+                    windowsfixed = Sinfo;
+                }
+
+                // Detect Wine/Proton layer when running on Linux
+                string wineTag = DetectWineLayer();
+                if (!string.IsNullOrEmpty(wineTag))
+                    windowsfixed += $" {wineTag}";
+
+                return windowsfixed;
+            }
+
+            // Native Linux detection
+            if (Sinfo.Contains("Linux"))
+            {
+                string distroInfo = GetLinuxDistroInfo();
+                if (!string.IsNullOrEmpty(distroInfo))
+                    return $"{Sinfo} ({distroInfo})";
             }
         }
         catch (Exception ex)
@@ -152,6 +207,58 @@ public partial class ModLoader
             Console.WriteLine(ex);
         }
         return Sinfo;
+    }
+
+    /// <summary>
+    /// Detect if running under Wine or Proton.
+    /// Returns "[Proton]" or "[Wine]" or null.
+    /// </summary>
+    private static string DetectWineLayer()
+    {
+        try
+        {
+            // Proton sets STEAM_COMPAT_DATA_PATH
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("STEAM_COMPAT_DATA_PATH")))
+                return "[Proton]";
+            // Wine sets WINEPREFIX or WINELOADERNOEXEC
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WINEPREFIX"))
+                || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WINELOADERNOEXEC")))
+                return "[Wine]";
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex);
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Read Linux distribution info from /etc/os-release.
+    /// Returns "Ubuntu 24.04" style string, or null.
+    /// </summary>
+    private static string GetLinuxDistroInfo()
+    {
+        try
+        {
+            string osRelease = "/etc/os-release";
+            if (!File.Exists(osRelease)) return null;
+            string name = null;
+            string version = null;
+            foreach (string line in File.ReadAllLines(osRelease))
+            {
+                if (line.StartsWith("NAME="))
+                    name = line.Substring(5).Trim('"');
+                else if (line.StartsWith("VERSION_ID="))
+                    version = line.Substring(11).Trim('"');
+            }
+            if (name != null)
+                return version != null ? $"{name} {version}" : name;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex);
+        }
+        return null;
     }
 }
 

--- a/MSCLoader/MSCLoader/ModMenu/MenuElementList.cs
+++ b/MSCLoader/MSCLoader/ModMenu/MenuElementList.cs
@@ -407,9 +407,12 @@ namespace MSCLoader
             {
                 zip.AddFile(Path.Combine(dir, "bugReport.json"), "");
                 zip.AddFile(Path.Combine(dir, "ModList.txt"), "");
-                zip.AddFile(Path.Combine(".", "output_log.txt"), "");
-                if (File.Exists(Path.Combine(".", "output_log_previous.txt")))
-                    zip.AddFile(Path.Combine(".", "output_log_previous.txt"), "");
+                string logPath = ModLoader.GetOutputLogPath();
+                if (logPath != null && File.Exists(logPath))
+                    zip.AddFile(logPath, "");
+                string prevLogPath = ModLoader.GetOutputLogPreviousPath();
+                if (prevLogPath != null && File.Exists(prevLogPath))
+                    zip.AddFile(prevLogPath, "");
                 if (report.bugReportSaveFile)
                 {
 #if MSC


### PR DESCRIPTION
## Summary

Improves Linux compatibility in three areas:
1. **Wine/Proton detection** in `SystemInfoFix()` — user-agent headers and log output now show `[Proton]` or `[Wine]` tag when running under a compatibility layer. Native Linux shows distro info from `/etc/os-release`.
2. **Cross-platform output log path** — `OnApplicationQuit()` and bug report zip now find the log file on both Windows (`output_log.txt`) and Linux (`Player.log`).
3. **OutputLogChecker guard** — skip binary `mainData` patching on native Linux where offsets differ and `Player.log` is the default.

## Problem

On **Linux/Proton**, `SystemInfo.operatingSystem` reports a Windows version string, making it impossible to distinguish native Windows users from Linux/Proton users in server-side logs, user-agent analytics, and bug reports.

On **native Linux**, Unity writes its log to `~/.config/unity3d/Amistech/<Game>/Player.log` instead of `output_log.txt`. The current code:
- `OnApplicationQuit()` calls `File.Copy("output_log.txt", ...)` which throws `FileNotFoundException` and silently fails.
- Bug report zip tries to add `output_log.txt` which doesn't exist → bug reports have no log data.
- `OutputLogChecker()` patches binary offsets in `mainData` that may differ between Windows and Linux builds.

Related: #164, #283

## Changes

| File | Change |
|------|--------|
| `ModLoader.Internal.cs` | `OnApplicationQuit()` — use `GetOutputLogPath()` + try/catch |
| `ModLoader.Internal.cs` | Add `GetOutputLogPath()`, `GetOutputLogPreviousPath()` helpers |
| `ModLoader.Internal.cs` | `SystemInfoFix()` — detect Wine/Proton via env vars, read `/etc/os-release` on native Linux |
| `ModLoader.Internal.cs` | Add `DetectWineLayer()`, `GetLinuxDistroInfo()` private helpers |
| `MenuElementList.cs` | Bug report zip — use `GetOutputLogPath()` instead of hardcoded `output_log.txt` |
| `MainEntry.cs` | `OutputLogChecker()` — skip binary patching on native Linux (`PlatformID.Unix` without Wine env vars) |

## Backward compatibility

**Zero behavior change on Windows:**
- `output_log.txt` always exists → `GetOutputLogPath()` returns it immediately.
- Wine/Proton env vars are absent → `DetectWineLayer()` returns null → no tag appended.
- `PlatformID.Unix` check is false → `OutputLogChecker()` runs as before.

**Linux/Proton:**
- `output_log.txt` usually exists in Wine prefix → works as before, plus `[Proton]` tag in SystemInfo.
- If Wine doesn't create `output_log.txt`, falls back to `Player.log`.

**Native Linux (experimental):**
- `Player.log` is found via `Application.persistentDataPath`.
- Binary patching skipped (correct behavior — offsets differ).
- Distro name/version shown in SystemInfo.

All new code paths are wrapped in try/catch — if anything fails, original behavior is preserved.

## SystemInfoFix output examples

| Scenario | Before | After |
|----------|--------|-------|
| Windows 11 | `Windows 11 (10.0.22631) 64bit` | `Windows 11 (10.0.22631) 64bit` ← unchanged |
| Linux + Proton | `Windows 10 (10.0.19041) 64bit` | `Windows 10 (10.0.19041) 64bit [Proton]` |
| Linux + Wine | `Windows 10 (10.0.19041) 64bit` | `Windows 10 (10.0.19041) 64bit [Wine]` |
| Native Linux | `Linux 6.8 Ubuntu 64bit` | `Linux 6.8 Ubuntu 64bit (Ubuntu 24.04)` |

## Testing

Tested on Ubuntu 24.04 with Proton 9.x and My Winter Car.